### PR TITLE
Fix: Argument #1 ($title) must be of type string

### DIFF
--- a/src/EventListener/Contao/ParseTemplateListener.php
+++ b/src/EventListener/Contao/ParseTemplateListener.php
@@ -66,7 +66,7 @@ class ParseTemplateListener
                 }
             }
 
-            $context = new SyndicationContext($template->title, $buffer, $this->requestStack->getMasterRequest()->getUri(), $template->getData(), $template->getData());
+            $context = new SyndicationContext((string) $template->title, $buffer, $this->requestStack->getMasterRequest()->getUri(), $template->getData(), $template->getData());
             $this->exportSyndicationHandler->exportByContext($context);
         }
     }


### PR DESCRIPTION
There was a null error in the Admin panel when the Article contains another Article and the $title is null.

Would be nice if you could merge the pull.
A new release would be awesome if it is accepted.
Same procedure as last time :-)